### PR TITLE
fix: guard coin collision check when no next coin is available

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -207,8 +207,13 @@ function gameloop() {
     return;
   }
 
-  // determine the bounding box of the next pipes inner area
+  // determine the bounding box of the next coin area
   var nextcoin = coins.find(c => c.dX > playerBB.left - 20);
+
+  // all coins may already be behind the player between spawn ticks
+  if (!nextcoin) {
+    return;
+  }
 
   var coinBB = nextcoin.getBoundingBox();
 


### PR DESCRIPTION
## Summary
- Guarded coin collision handling in `gameloop` when no forward coin exists for the current frame.
- Prevented `nextcoin.getBoundingBox()` from being called on `undefined`.

## Why
There is a short gameplay window where all currently spawned coins can be behind the player between spawn ticks. In that case, `coins.find(...)` returns `undefined`, which can cause a runtime error.

## Testing
- `node --check js/main.js`
